### PR TITLE
fix document bug. cookie name option is not 'cookie_key' but 'name'.

### DIFF
--- a/lib/HTTP/Session.pm
+++ b/lib/HTTP/Session.pm
@@ -190,7 +190,7 @@ HTTP::Session - simple session
             }),
         ),
         state   => HTTP::Session::State::Cookie->new(
-            cookie_key => 'foo_sid'
+            name => 'foo_sid'
         ),
         request => $c->req,
     );


### PR DESCRIPTION
cookie name option is not 'cookie_key' but 'name'.
