### PR TITLE
enable to set secure, httponly and samesite options.

### DIFF
--- a/lib/HTTP/Session/State/Cookie.pm
+++ b/lib/HTTP/Session/State/Cookie.pm
@@ -6,7 +6,7 @@ use Scalar::Util ();
 
 our $COOKIE_CLASS = 'CGI::Cookie';
 
-__PACKAGE__->mk_accessors(qw/name path domain expires/);
+__PACKAGE__->mk_accessors(qw/name path domain expires secure samesite httponly/);
 
 {
     my $required = 0;
@@ -62,6 +62,9 @@ sub header_filter {
             );
             $options{'-domain'} = $self->domain if $self->domain;
             $options{'-expires'} = $self->expires if $self->expires;
+            $options{'-secure'} = $self->secure if $self->secure;
+            $options{'-samesite'} = $self->samesite if $self->samesite;
+            $options{'-httponly'} = $self->httponly if $self->httponly;
             %options;
         }->()
     );

--- a/t/030_state/002_cookie.t
+++ b/t/030_state/002_cookie.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 12;
+use Test::More tests => 17;
 use CGI;
 use t::CookieTest;
 

--- a/t/030_state/007_cookie_simple.t
+++ b/t/030_state/007_cookie_simple.t
@@ -4,7 +4,7 @@ use Test::More;
 use t::CookieTest;
 use CGI::Simple;
 plan skip_all => "this test requires CGI::Simple" unless eval "use CGI::Simple; 1";
-plan tests => 16;
+plan tests => 21;
 
 # XXX use CGI::Simple::Cookie
 $HTTP::Session::State::Cookie::COOKIE_CLASS = 'CGI::Simple::Cookie';


### PR DESCRIPTION
Chrome 80 will block third party cookie which doesn't have SameSite=None and secure flag.

This patches enables to set SameSite option, secure flag and httponly flag to cookie.

httponly is not related on third party cookie problem. But 
I added it because of same kind of feature.



