### PR TITLE
enable to set httponly and samesite cookie options.

### DIFF
--- a/META.json
+++ b/META.json
@@ -52,7 +52,8 @@
             "HTML::StickyQuery" : "0.12"
          },
          "requires" : {
-            "CGI::Simple::Cookie" : "1.103",
+            "CGI" : "4.45",
+            "CGI::Simple::Cookie" : "1.22",
             "Class::Accessor::Fast" : "0.31",
             "Digest::SHA1" : "2.11",
             "Exporter" : "5.63",

--- a/lib/HTTP/Session/State/Cookie.pm
+++ b/lib/HTTP/Session/State/Cookie.pm
@@ -6,7 +6,7 @@ use Scalar::Util ();
 
 our $COOKIE_CLASS = 'CGI::Cookie';
 
-__PACKAGE__->mk_accessors(qw/name path domain expires secure/);
+__PACKAGE__->mk_accessors(qw/name path domain expires secure samesite httponly/);
 
 {
     my $required = 0;
@@ -63,6 +63,8 @@ sub header_filter {
             $options{'-domain'} = $self->domain if $self->domain;
             $options{'-expires'} = $self->expires if $self->expires;
             $options{'-secure'} = $self->secure if $self->secure;
+            $options{'-samesite'} = $self->samesite if $self->samesite;
+            $options{'-httponly'} = $self->httponly if $self->httponly;
             %options;
         }->()
     );

--- a/t/030_state/002_cookie.t
+++ b/t/030_state/002_cookie.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 14;
+use Test::More tests => 19;
 use CGI;
 use t::CookieTest;
 

--- a/t/030_state/007_cookie_simple.t
+++ b/t/030_state/007_cookie_simple.t
@@ -4,7 +4,7 @@ use Test::More;
 use t::CookieTest;
 use CGI::Simple;
 plan skip_all => "this test requires CGI::Simple" unless eval "use CGI::Simple; 1";
-plan tests => 18;
+plan tests => 23;
 
 # XXX use CGI::Simple::Cookie
 $HTTP::Session::State::Cookie::COOKIE_CLASS = 'CGI::Simple::Cookie';

--- a/t/CookieTest.pm
+++ b/t/CookieTest.pm
@@ -108,6 +108,49 @@ sub test {
     sub {
         local $ENV{HTTP_COOKIE} = 'foo_sid=bar; path=/admin/;';
 
+	for my $option ([secure => 1], [HttpOnly => 1]) {
+            my $session = HTTP::Session->new(
+                store => $store,
+                state => HTTP::Session::State::Cookie->new(
+                    name    => 'foo_sid',
+                    lc($option->[0]) => $option->[1],
+                ),
+                request => $cgi->new
+            );
+            my $res = HTTP::Response->new(200, 'foo');
+            $session->response_filter($res);
+
+            is $res->header('Set-Cookie'), 'foo_sid=bar; path=/; '. $option->[0], "@$option";
+        }
+    }->();
+
+    sub {
+        local $ENV{HTTP_COOKIE} = 'foo_sid=bar; path=/admin/;';
+
+	for my $option ([SameSite => 'None'], [SameSite => 'Lax'], [SameSite => 'Strict']) {
+          SKIP: {
+            my $session = HTTP::Session->new(
+                store => $store,
+                state => HTTP::Session::State::Cookie->new(
+                    name    => 'foo_sid',
+                    lc($option->[0]) => $option->[1],
+                ),
+                request => $cgi->new
+            );
+            my $res = HTTP::Response->new(200, 'foo');
+            $session->response_filter($res);
+
+            skip "CGI::Simple 1.22 doesn't support SameSite=None", 1 if $option->[1] eq 'None' and $HTTP::Session::State::Cookie::COOKIE_CLASS eq 'CGI::Simple::Cookie';
+            my $option_string = $option->[0] . '=' . $option->[1];
+            is $res->header('Set-Cookie'), 'foo_sid=bar; path=/; '. $option_string, "@$option";
+          }
+        }
+    }->();
+
+
+    sub {
+        local $ENV{HTTP_COOKIE} = 'foo_sid=bar; path=/admin/;';
+
         my $session = HTTP::Session->new(
             store => $store,
             state => HTTP::Session::State::Cookie->new(


### PR DESCRIPTION
Chrome 80 will block third party cookie which doesn't have SameSite=None and secure flag.

This patches enables to set SameSite option and httponly flag to cookie.

httponly is not related on third party cookie problem. 
But I added it because of same kind of feature.