### PR TITLE
Fix regexp in t/CookieTest.pm

### DIFF
--- a/t/CookieTest.pm
+++ b/t/CookieTest.pm
@@ -95,13 +95,13 @@ sub test {
         {
             my $res = HTTP::Response->new(200, 'foo');
             $session->response_filter($res);
-            like $res->header('Set-Cookie'), qr!foo_sid=bar; path=/; expires=[A-Z][a-z]{2}, \d+-[A-Z][a-z]{2}-\d{4} \d\d:\d\d:\d\d GMT!;
+            like $res->header('Set-Cookie'), qr!foo_sid=bar; path=/; expires=[A-Z][a-z]{2}, \d+([- ])[A-Z][a-z]{2}\1\d{4} \d\d:\d\d:\d\d GMT!;
         }
 
         {
             my $res = HTTP::Response->new(200, 'foo');
             $session->header_filter($res);
-            like $res->header('Set-Cookie'), qr!foo_sid=bar; path=/; expires=[A-Z][a-z]{2}, \d+-[A-Z][a-z]{2}-\d{4} \d\d:\d\d:\d\d GMT!;
+            like $res->header('Set-Cookie'), qr!foo_sid=bar; path=/; expires=[A-Z][a-z]{2}, \d+([- ])[A-Z][a-z]{2}\1\d{4} \d\d:\d\d:\d\d GMT!;
         }
     }->();
 


### PR DESCRIPTION
- CGI version 4.58 fixed the format of the cookie expiration date, and the regexp in t/CookieTest.pm will fail. Fixed the regexp to pass with both the old and new versions of CGI.