### PR TITLE
Filter session ids in HTTP::Session::Store::CHI

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl module HTTP::Session
 
 {{$NEXT}}
 
+   - HTTP::Session::Store::CHI now filters session ids the same way
+     HTTP::Session::Store::Memcached does, rejecting control characters
+     and overly long ids before passing them to the backend.
+
 0.53 2024-03-07T05:47:13Z
 
    - version up to fix PUUSE indexing problem.

--- a/lib/HTTP/Session/Store/CHI.pm
+++ b/lib/HTTP/Session/Store/CHI.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use base qw/Class::Accessor::Fast/;
 use CHI;
+use Encode qw( encode_utf8 is_utf8 );
 
 __PACKAGE__->mk_ro_accessors(qw/chi expires/);
 
@@ -20,24 +21,33 @@ sub new {
     bless {%args}, $class;
 }
 
+sub _filter_sid($) {
+    my $session_id = shift;
+    $session_id = encode_utf8($session_id) if is_utf8($session_id);
+    if ($session_id =~ /[\x00-\x20\x7f-\xff]/ || length($session_id) > 250) {
+        die "detected memcached injection: $session_id";
+    }
+    return $session_id;
+}
+
 sub select {
     my ( $self, $session_id ) = @_;
-    my $data = $self->chi->get($session_id);
+    my $data = $self->chi->get(_filter_sid $session_id);
 }
 
 sub insert {
     my ($self, $session_id, $data) = @_;
-    $self->chi->set( $session_id, $data, $self->expires );
+    $self->chi->set( _filter_sid($session_id), $data, $self->expires );
 }
 
 sub update {
     my ($self, $session_id, $data) = @_;
-    $self->chi->set( $session_id, $data, $self->expires );
+    $self->chi->set( _filter_sid($session_id), $data, $self->expires );
 }
 
 sub delete {
     my ($self, $session_id) = @_;
-    $self->chi->remove( $session_id );
+    $self->chi->remove( _filter_sid($session_id) );
 }
 
 sub cleanup { Carp::croak "This storage doesn't support cleanup" }

--- a/t/020_store/006_chi.t
+++ b/t/020_store/006_chi.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use lib qw(../../ .);
 use Test::Requires 'CHI';
-use Test::More tests => 4*2;
+use Test::More tests => (4 + 12) * 2;
 use t::Exception;
 use HTTP::Session;
 use CGI;
@@ -32,5 +32,30 @@ sub run_tests {
     is $store->select('foo'), undef;
     $store->insert('foo' => {boo => 'fy'});
     is $store->select('foo')->{'boo'}, 'fy', 'complex';
+
+    my $bad_key = "x" x 1024 . rand();
+    injection(sub { $store->select($bad_key); });
+    injection(sub { $store->insert($bad_key, {foo => 'bar'}); });
+    injection(sub { $store->update($bad_key, {foo => 'bar'}); });
+
+    $bad_key = "x\r\nstats\r\n" . rand();
+    injection(sub { $store->select($bad_key); });
+    injection(sub { $store->insert($bad_key, {foo => 'bar'}); });
+    injection(sub { $store->update($bad_key, {foo => 'bar'}); });
+
+    $bad_key = "m e m c a c h e d" . rand();
+    injection(sub { $store->select($bad_key); });
+    injection(sub { $store->insert($bad_key, {foo => 'bar'}); });
+    injection(sub { $store->update($bad_key, {foo => 'bar'}); });
+
+    $bad_key = qq!\x{3042}!x100;
+    injection(sub { $store->select($bad_key); });
+    injection(sub { $store->insert($bad_key, {foo => 'bar'}); });
+    injection(sub { $store->update($bad_key, {foo => 'bar'}); });
 }
 
+sub injection {
+    my $code = shift;
+    eval { $code->() };
+    like $@, qr/injection/;
+}


### PR DESCRIPTION
## Summary

`HTTP::Session::Store::CHI` passed the session id straight through to the
underlying CHI backend, while its sibling `HTTP::Session::Store::Memcached`
runs every id through a `_filter_sid` check first. This ports that same
discipline to the CHI store so both behave consistently.

`_filter_sid` UTF-8-encodes the id and rejects any control characters
(`[\x00-\x20\x7f-\xff]`) or ids longer than 250 bytes before they reach the
backend. It now wraps the id in all four operations: `select`, `insert`,
`update`, and `delete`.

## Tests

`t/020_store/006_chi.t` gains injection assertions mirroring
`t/020_store/002_memcached.t` — over-long, control-character, whitespace, and
wide-character ids are each exercised across `select`/`insert`/`update` for
both CHI store configurations.

Full suite passes (`Files=31, Tests=171, Result: PASS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code) by Olaf Alders (Claude Opus 4.8)
