### PR TITLE
Deprecate HTTP::Session in favor of Plack::Middleware::Session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Makefile.old
 !Build/
 !META.json
 !LICENSE
+/http-session-*

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl module HTTP::Session
 
 {{$NEXT}}
 
+   - This distribution is now deprecated (x_deprecated). Use
+     Plack::Middleware::Session instead. This module will no longer be
+     maintained or receive further updates.
    - HTTP::Session::ID::Urandom now draws from Crypt::URandom instead of
      reading /dev/urandom directly, for portability and speed, and is now the
      default session-ID backend.

--- a/META.json
+++ b/META.json
@@ -1,10 +1,10 @@
 {
-   "abstract" : "simple session",
+   "abstract" : "(DEPRECATED) simple session",
    "author" : [
       "Tokuhiro Matsuno <tokuhirom AAJKLFJEF GMAIL COM>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v3.1.23, CPAN::Meta::Converter version 2.150010",
+   "generated_by" : "Minilla/v3.1.29, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -84,12 +84,14 @@
       "Atsushi Kato <ktat@cpan.org>",
       "MATSUU Takuto <matsuu@gmail.com>",
       "Neil Bowers <neil@bowers.com>",
+      "Olaf Alders <olaf@wundersolutions.com>",
       "Tokuhiro Matsuno <tokuhirom@gmail.com>",
       "kazuho <kazuho@d0d07461-0603-4401-acd4-de1884942a52>",
       "tohae <tohaechan@gmail.com>",
       "tokuhirom <tokuhirom@d0d07461-0603-4401-acd4-de1884942a52>",
       "yappo <yappo@d0d07461-0603-4401-acd4-de1884942a52>"
    ],
-   "x_serialization_backend" : "JSON::PP version 4.06",
+   "x_deprecated" : 1,
+   "x_serialization_backend" : "JSON::PP version 4.16",
    "x_static_install" : 1
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NAME
 
-HTTP::Session - simple session
+HTTP::Session - (DEPRECATED) simple session
 
 # SYNOPSIS
 
@@ -20,6 +20,8 @@ HTTP::Session - simple session
 
 # DESCRIPTION
 
+**This module is deprecated.** Use [Plack::Middleware::Session](https://metacpan.org/pod/Plack%3A%3AMiddleware%3A%3ASession) instead.
+
 Yet another session manager.
 
 easy to integrate with [PSGI](https://metacpan.org/pod/PSGI) =)
@@ -36,6 +38,20 @@ easy to integrate with [PSGI](https://metacpan.org/pod/PSGI) =)
 
     `request` is duck typed object.`request` object should have `header`, `address`, `param`.
     You can use PSGI's $env instead.
+
+    `id` selects the session-ID generator class (default:
+    [HTTP::Session::ID::Urandom](https://metacpan.org/pod/HTTP%3A%3ASession%3A%3AID%3A%3AUrandom), which draws from [Crypt::URandom](https://metacpan.org/pod/Crypt%3A%3AURandom)). The
+    `HTTP::Session::ID::MD5` and `HTTP::Session::ID::SHA1` backends are also
+    supported; as of CVE-2026-3256 they hash cryptographically secure random bytes
+    (from [Crypt::URandom](https://metacpan.org/pod/Crypt%3A%3AURandom)) instead of their former predictable time/PID/`rand()`
+    input, while keeping their hexadecimal output. Each backend has its own
+    session-ID alphabet: `Urandom` uses URL-safe Base64 (`[A-Za-z0-9_-]`), while
+    `MD5` and `SHA1` use lowercase hexadecimal (`[0-9a-f]`).
+
+    `sid_length` defaults to 32, which yields at least 128 bits of entropy with any
+    backend (192 bits with `Urandom`). Lowering it is supported, but reduces the
+    entropy of the session ID proportionally; values around 22 or below drop under
+    the 128-bit level generally recommended for session identifiers.
 
 - $session->html\_filter($html)
 

--- a/lib/HTTP/Session.pm
+++ b/lib/HTTP/Session.pm
@@ -177,7 +177,7 @@ __END__
 
 =head1 NAME
 
-HTTP::Session - simple session
+HTTP::Session - (DEPRECATED) simple session
 
 =head1 SYNOPSIS
 
@@ -196,6 +196,8 @@ HTTP::Session - simple session
     );
 
 =head1 DESCRIPTION
+
+B<This module is deprecated.> Use L<Plack::Middleware::Session> instead.
 
 Yet another session manager.
 

--- a/minil.toml
+++ b/minil.toml
@@ -1,1 +1,4 @@
 module_maker="ModuleBuildTiny"
+
+[Metadata]
+x_deprecated = 1


### PR DESCRIPTION
## Summary

Mark the distribution as deprecated and direct users to `Plack::Middleware::Session`.

- Add `x_deprecated = 1` to `minil.toml` (`[Metadata]`) so MetaCPAN shows the DEPRECATED badge.
- Add `(DEPRECATED)` to the NAME abstract and a deprecation notice to DESCRIPTION in the POD (and regenerated README).
- `Changes` notes that this module will no longer be maintained; users should migrate to `Plack::Middleware::Session`.

## Why

Beyond the recently fixed session-ID CVE, the module retains architectural weaknesses (unescaped session id in `State::URI`'s `html_filter`, no secure-by-default cookie flags, legacy `$ENV{HTTP_COOKIE}` lookup). These are better addressed by `Plack::Middleware::Session`, so the module is deprecated rather than further patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)